### PR TITLE
Resolve #33 - Missing Special Improvements in Theme Advancement window

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -235,6 +235,7 @@
 			"scene_limits": "Scene Limits",
 			"scene_tag_dialog_title": "Scene Tags",
 			"scene_tag_dialog_hint": "Define tags, statuses, and limits for this scene.",
+			"activate_improvement": "Activate Improvement",
 			"activate_tag": "Activate Tag",
 			"hide": "Hide",
 			"show": "Show",

--- a/scripts/apps/theme-advancement.js
+++ b/scripts/apps/theme-advancement.js
@@ -21,6 +21,7 @@ export class ThemeAdvancementApp extends foundry.applications.api.HandlebarsAppl
 			addWeaknessTag: ThemeAdvancementApp.#onAddWeaknessTag,
 			activatePowerTag: ThemeAdvancementApp.#onActivatePowerTag,
 			activateWeaknessTag: ThemeAdvancementApp.#onActivateWeaknessTag,
+			activateSpecialImprovement: ThemeAdvancementApp.#onActivateSpecialImprovement,
 		},
 	};
 
@@ -99,6 +100,13 @@ export class ThemeAdvancementApp extends foundry.applications.api.HandlebarsAppl
 			}))
 			.filter((_, index) => !theme.system.weaknessTags[index].isActive);
 
+		const inactiveSpecialImprovements = (theme.system?.specialImprovements || [])
+			.map((improvement, index) => ({
+				value: String(index),
+				label: improvement.name || game.i18n.localize("LITM.Ui.improvement_name"),
+			}))
+			.filter((_, index) => !theme.system.specialImprovements[index]?.isActive);
+
 		const allPowerQuestions =
 			selectedThemebook?.system?.powerTagQuestions || [];
 		const allWeaknessQuestions =
@@ -128,7 +136,9 @@ export class ThemeAdvancementApp extends foundry.applications.api.HandlebarsAppl
 			specialImprovementOptions,
 			specialImprovementDescriptions,
 			inactivePowerTags,
+			inactivePowerTags,
 			inactiveWeaknessTags,
+			inactiveSpecialImprovements,
 			powerQuestionOptions,
 			weaknessQuestionOptions,
 			powerQuestionTexts,
@@ -319,6 +329,29 @@ export class ThemeAdvancementApp extends foundry.applications.api.HandlebarsAppl
 
 		await ThemeAdvancementApp.#spendImprove(theme, {
 			"system.weaknessTags": weaknessTags,
+		});
+		this.close();
+	}
+
+	static async #onActivateSpecialImprovement(_event, target) {
+		const theme = ThemeAdvancementApp.#getTheme.call(this);
+		if (!theme || !ThemeAdvancementApp.#canSelect(theme)) return;
+		const container = target.closest("fieldset");
+		const select = container?.querySelector(
+			"[data-role='inactive-special-improvement-select']",
+		);
+		const index = Number(select?.value ?? "");
+		if (Number.isNaN(index)) return;
+
+		const specialImprovements = [...(theme.system?.specialImprovements || [])];
+		if (!specialImprovements[index]) return;
+		specialImprovements[index] = {
+			...specialImprovements[index],
+			isActive: true,
+		};
+
+		await ThemeAdvancementApp.#spendImprove(theme, {
+			"system.specialImprovements": specialImprovements,
 		});
 		this.close();
 	}

--- a/templates/apps/theme-advancement.html
+++ b/templates/apps/theme-advancement.html
@@ -17,6 +17,19 @@
 	<fieldset>
 		<legend>{{localize "LITM.Ui.special_improvements"}}</legend>
 		{{#if canSelect}}
+		{{#if inactiveSpecialImprovements.length}}
+		<div class="form-group">
+			<select data-role="inactive-special-improvement-select"
+				aria-label="{{localize 'LITM.Ui.special_improvements'}}" style="flex: 1;">
+				{{selectOptions inactiveSpecialImprovements blank="—"}}
+			</select>
+			<button type="button" data-action="activateSpecialImprovement"
+				data-tooltip="{{localize 'LITM.Ui.activate_improvement'}}"
+				aria-label="{{localize 'LITM.Ui.activate_improvement'}}">
+				<i class="fa-solid fa-check" aria-hidden="true"></i>
+			</button>
+		</div>
+		{{/if}}
 		{{#if specialImprovementOptions.length}}
 		<div class="form-group">
 			<select data-role="special-improvement-select" data-descriptions="{{toJSON specialImprovementDescriptions}}"


### PR DESCRIPTION
### Description
- Ensure special improvements added from ThemeAdvancementApp are created with isActive: true
- Add dropdown + activate button to the Theme Advancement modal for existing inactive special improvements

### Screenshots
New _Theme Advancement_ UI
<img width="1455" height="1234" alt="New_UI" src="https://github.com/user-attachments/assets/c4798afb-6e84-4da3-8953-9d144dfeae8b" />

Improvement activation dropdown
<img width="1452" height="1238" alt="Activation_dropdown" src="https://github.com/user-attachments/assets/e1190bf8-e1a7-4308-8ac5-c9047bbac536" />

Improvement addition dropdown
<img width="1449" height="1238" alt="Addition_dropdown" src="https://github.com/user-attachments/assets/0e892679-7cf7-4285-98b6-7c570c07672e" />
