### PR TITLE
fix: Filter-out vignette owned effects from actors active effects in Tags/Statuses management sidebar

### DIFF
--- a/modules/actor/challenge/challenge-data.js
+++ b/modules/actor/challenge/challenge-data.js
@@ -256,4 +256,17 @@ export class ChallengeData extends LimitsMixin(
 	async syncEffectsFromTagString(tagsString) {
 		return syncTagStringEffects(this.parent, tagsString);
 	}
+
+	/**
+	 * Challenge vignettes may carry ActiveEffects for consequence markup.
+	 * Exclude those vignette-owned effects from the actor's story/status
+	 * collections so they do not appear in the story-tag sidebar.
+	 */
+	get storyTags() {
+		return super.storyTags.filter((e) => e.parent?.type !== "vignette");
+	}
+
+	get statusEffects() {
+		return super.statusEffects.filter((e) => e.parent?.type !== "vignette");
+	}
 }

--- a/modules/actor/journey/journey-data.js
+++ b/modules/actor/journey/journey-data.js
@@ -39,4 +39,17 @@ export class JourneyData extends LimitsMixin(
 	async syncEffectsFromTagString(tagsString) {
 		return syncTagStringEffects(this.parent, tagsString);
 	}
+
+	/**
+	 * Journey vignettes may carry ActiveEffects for consequence markup.
+	 * Exclude those vignette-owned effects from the actor's story/status
+	 * collections so they do not appear in the story-tag sidebar.
+	 */
+	get storyTags() {
+		return super.storyTags.filter((e) => e.parent?.type !== "vignette");
+	}
+
+	get statusEffects() {
+		return super.statusEffects.filter((e) => e.parent?.type !== "vignette");
+	}
 }


### PR DESCRIPTION
## Context
Journey and Challenge vignette items can carry ActiveEffects for consequence markup. Those vignette-owned effects were leaking into the sidebar actor tag/status collections.

The fix for #107 keeps vignette effects out of the "Manage Tags & Statuses" sidebar display
## Fix
- Added overrides for storyTags and statusEffects in Challenges and Journeys
- Filtered out effects whose parent document type is vignette