### PR TITLE
fix: Roll dialog interactions

### DIFF
--- a/modules/actor/hero/hero-sheet.js
+++ b/modules/actor/hero/hero-sheet.js
@@ -6,6 +6,7 @@ import {
 } from "../../active-effects/effect-queries.js";
 import { scratchTag } from "../../active-effects/scratchable-mixin.js";
 import { ActionsApp } from "../../apps/actions-app.js";
+import { findBurnedSelection } from "../../apps/roll/burn-cap.js";
 import { resolveRollDialogOwnership } from "../../apps/roll/roll-dialog.js";
 import { LitmActorSheet } from "../../sheets/base-actor-sheet.js";
 import { LitmSettings } from "../../system/settings.js";
@@ -570,6 +571,18 @@ export class HeroSheet extends LitmActorSheet {
 					? "scratched"
 					: states[states.length - 1]
 				: states[1];
+			// Burn cap (p.158): refuse a second burn from the sheet, mirroring the
+			// roll dialog. Leave the tag untouched rather than silently swallowing
+			// the burn into a different state.
+			if (
+				nextState === "scratched" &&
+				findBurnedSelection(this.rollDialogInstance.selections, tagKey)
+			) {
+				ui.notifications.warn(
+					game.i18n.localize("LITM.Ui.burn_cap_warning"),
+				);
+				return;
+			}
 			this.rollDialogInstance.setCharacterTagState(tagKey, nextState);
 		}
 

--- a/modules/apps/roll/burn-cap.js
+++ b/modules/apps/roll/burn-cap.js
@@ -1,0 +1,37 @@
+/**
+ * Burn cap (Core Book p.158): a roll may burn at most one tag. "Burning" sets a
+ * tag's roll-selection state to "scratched". These pure helpers let the three
+ * tag-selection entry points (dialog cycle, dialog shift-burn, sheet
+ * shift-burn) enforce that single rule consistently and testably.
+ */
+
+/**
+ * Find a tag, other than `excludeId`, that is already burned in this roll.
+ *
+ * @param {Map<string, {state?: string}>} selectionMap  The roll's selection map.
+ * @param {string} excludeId  The tag being changed (so it can be re-burned or
+ *   toggled off without blocking itself).
+ * @returns {string|null} The id of an already-burned tag, or null if none.
+ */
+export function findBurnedSelection(selectionMap, excludeId) {
+	for (const [id, entry] of selectionMap) {
+		if (id !== excludeId && entry?.state === "scratched") return id;
+	}
+	return null;
+}
+
+/**
+ * The cycle state that follows "scratched" in a super-checkbox `states` order,
+ * wrapping at the end. Used to skip past a blocked burn instead of trapping the
+ * cursor: the GM power-tag cycle is `,positive,scratched,negative`, so skipping
+ * scratched must land on "negative" (the Narrator inversion, p.76), while
+ * cycles where scratched is last simply wrap back to "off".
+ *
+ * @param {string[]} states  Ordered cycle states (e.g. ["", "positive", "scratched", "negative"]).
+ * @returns {string} The next state after "scratched", or "" if absent.
+ */
+export function nextStateAfterScratched(states) {
+	const i = states.indexOf("scratched");
+	if (i === -1) return "";
+	return states[(i + 1) % states.length];
+}

--- a/modules/apps/roll/roll-dialog.js
+++ b/modules/apps/roll/roll-dialog.js
@@ -11,6 +11,7 @@ import {
 import { LitmEmbedPopout } from "../embed-popout.js";
 import { mitigationBannerText } from "../mitigation.js";
 import { StoryTagsStore } from "../story-tags/story-tags-store.js";
+import { findBurnedSelection, nextStateAfterScratched } from "./burn-cap.js";
 import { LitmRoll } from "./roll.js";
 import {
 	buildActionContext,
@@ -232,8 +233,19 @@ export class LitmRollDialog extends foundry.applications.api.HandlebarsApplicati
 		if (event.shiftKey && !checkbox.disabled) {
 			const canScratch = checkbox.getAttribute("states")?.includes("scratched");
 			if (canScratch) {
-				checkbox.value = checkbox.value === "scratched" ? "" : "scratched";
-				checkbox.dispatchEvent(new Event("change"));
+				const burning = checkbox.value !== "scratched";
+				// Burn cap (p.158): an explicit shift-to-burn is refused outright
+				// when another tag is already burned, leaving this tag untouched.
+				// (The natural cycle skips past instead — see `_onTagChange`.)
+				if (burning && findBurnedSelection(this.#selectionMap, checkbox.name)) {
+					ui.notifications?.warn(t("LITM.Ui.burn_cap_warning"));
+					return;
+				}
+				checkbox.value = burning ? "scratched" : "";
+				// Bubble so the delegated `_onTagChange` registers the selection
+				// (and applies the non-owner permission gate) — a non-bubbling
+				// event would set only the visual and never reach the handler.
+				checkbox.dispatchEvent(new Event("change", { bubbles: true }));
 				return;
 			}
 		}
@@ -900,20 +912,22 @@ export class LitmRollDialog extends foundry.applications.api.HandlebarsApplicati
 		}
 
 		// Burn cap: only one tag may be burned per roll (p.158). Skip past the
-		// scratched state to "off" instead of reverting — the checkbox cycle is
-		// …→negative→scratched→off, so reverting would trap the user, unable to
-		// cycle a selected tag back off while another tag is burned (#100).
-		if (value === "scratched") {
-			for (const [otherId, entry] of this.#selectionMap) {
-				if (otherId !== id && entry.state === "scratched") {
-					ui.notifications?.warn(t("LITM.Ui.burn_cap_warning"));
-					this.#revertTagChange(target, "");
-					this.setSelection(id, "");
-					this.#updateTotalPower();
-					this.#dispatchUpdate();
-					return;
-				}
-			}
+		// blocked scratched state to the NEXT state in this tag's own cycle
+		// instead of reverting to "off". For most cycles scratched is last, so
+		// the next state wraps to "" — but the GM power-tag cycle is
+		// `,positive,scratched,negative`, so skipping must land on "negative"
+		// (the Narrator inversion). Hard-reverting to "" would otherwise trap the
+		// cursor before "negative", making it unreachable while another tag is
+		// burned (#100).
+		if (value === "scratched" && findBurnedSelection(this.#selectionMap, id)) {
+			ui.notifications?.warn(t("LITM.Ui.burn_cap_warning"));
+			const states = (target.getAttribute("states") ?? "").split(",");
+			const next = nextStateAfterScratched(states);
+			this.#revertTagChange(target, next);
+			this.setSelection(id, next, next ? game.user.id : null);
+			this.#updateTotalPower();
+			this.#dispatchUpdate();
+			return;
 		}
 
 		const contributorId = value ? game.user.id : null;

--- a/tests/burn-cap.test.js
+++ b/tests/burn-cap.test.js
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import {
+	findBurnedSelection,
+	nextStateAfterScratched,
+} from "../modules/apps/roll/burn-cap.js";
+
+/**
+ * Burn cap (Core Book p.158): at most one tag may be burned ("scratched") per
+ * roll. Two helpers enforce it from three entry points (dialog cycle, dialog
+ * shift-burn, sheet shift-burn):
+ *
+ *  - `findBurnedSelection` answers "is some OTHER tag already burned?"
+ *  - `nextStateAfterScratched` lets the natural cycle skip past the blocked
+ *    scratched waypoint instead of being trapped — critical because the GM
+ *    power-tag cycle is `,positive,scratched,negative`, so "negative" sits
+ *    AFTER "scratched" and must stay reachable while another tag is burned.
+ */
+
+const mapOf = (entries) => new Map(Object.entries(entries));
+
+describe("findBurnedSelection", () => {
+	it("returns the id of an already-burned tag other than the excluded one", () => {
+		const map = mapOf({
+			a: { state: "positive" },
+			b: { state: "scratched" },
+		});
+		expect(findBurnedSelection(map, "a")).toBe("b");
+	});
+
+	it("ignores the excluded id so a tag can be (re)burned or toggled off", () => {
+		const map = mapOf({ b: { state: "scratched" } });
+		expect(findBurnedSelection(map, "b")).toBe(null);
+	});
+
+	it("returns null when no tag is burned", () => {
+		const map = mapOf({ a: { state: "positive" }, b: { state: "negative" } });
+		expect(findBurnedSelection(map, "a")).toBe(null);
+	});
+
+	it("returns null for an empty selection map", () => {
+		expect(findBurnedSelection(new Map(), "a")).toBe(null);
+	});
+});
+
+describe("nextStateAfterScratched", () => {
+	it("advances to negative for the GM power-tag cycle (scratched is a waypoint)", () => {
+		// ",positive,scratched,negative" → ["", "positive", "scratched", "negative"]
+		const states = ["", "positive", "scratched", "negative"];
+		expect(nextStateAfterScratched(states)).toBe("negative");
+	});
+
+	it("wraps to off for the player power-tag cycle (scratched is last)", () => {
+		// ",positive,scratched" → ["", "positive", "scratched"]
+		const states = ["", "positive", "scratched"];
+		expect(nextStateAfterScratched(states)).toBe("");
+	});
+
+	it("wraps to off for the multi-use story-tag cycle (scratched is last)", () => {
+		// ",positive,negative,scratched" → ["", "positive", "negative", "scratched"]
+		const states = ["", "positive", "negative", "scratched"];
+		expect(nextStateAfterScratched(states)).toBe("");
+	});
+
+	it("returns off when the cycle has no scratched state", () => {
+		expect(nextStateAfterScratched(["", "positive", "negative"])).toBe("");
+	});
+});


### PR DESCRIPTION
Scratching a tag prevented using other power tags as negative,
Shift-clicking bypassed scratch limit
